### PR TITLE
Parse with results

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The package can be installed by adding `high_roller` to your list of dependencie
 ```elixir
 def deps do
   [
-    {:high_roller, "~> 0.3.3"}
+    {:high_roller, "~> 0.4.0"}
   ]
 end
 ```

--- a/lib/high_roller/parser.ex
+++ b/lib/high_roller/parser.ex
@@ -31,12 +31,6 @@ defmodule HighRoller.Parser do
     end
   end
 
-  def output_current(current) do
-    IO.puts(IO.inspect(current))
-
-    current
-  end
-
   defp roll_dice_chunks([]), do: []
   defp roll_dice_chunks([roll_string | remaining]) do
     if String.match?(roll_string, ~r/[0-9]+d[0-9]+/) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule HighRoller.MixProject do
   def project do
     [
       app: :high_roller,
-      version: "0.3.3",
+      version: "0.4.0",
       elixir: "~> 1.8",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
@@ -35,7 +35,7 @@ defmodule HighRoller.MixProject do
       licenses: ["MIT"],
       links: %{
         "GitHub" => "https://github.com/NateBarnes/high_roller",
-        "Docs" => "https://hexdocs.pm/high_roller/0.3.0"
+        "Docs" => "https://hexdocs.pm/high_roller/0.4.0"
       }
     ]
   end

--- a/test/high_roller/parser_test.exs
+++ b/test/high_roller/parser_test.exs
@@ -78,7 +78,7 @@ defmodule HighRoller.ParserTest do
            [4, 8]
          end)
 
-      assert HighRoller.Parser.parse_with_results("2d8+5") == %{total: 17, full_results: [[4, 8], :+, 5]}
+      assert HighRoller.Parser.parse_with_results("2d8+5") == %{total: 17, full_results: [[4, 8], "+", 5]}
     end
   end
 end

--- a/test/high_roller/parser_test.exs
+++ b/test/high_roller/parser_test.exs
@@ -80,5 +80,14 @@ defmodule HighRoller.ParserTest do
 
       assert HighRoller.Parser.parse_with_results("2d8+5") == %{total: 17, full_results: [[4, 8], "+", 5]}
     end
+
+    test "it should gracefully fail when given an invalid input" do
+      HighRoller.RandomMock
+      |> stub(:roll, fn 2, 8 ->
+           [4, 8]
+         end)
+
+      assert HighRoller.Parser.parse_with_results("invalid input") == :error
+    end
   end
 end

--- a/test/high_roller/parser_test.exs
+++ b/test/high_roller/parser_test.exs
@@ -70,4 +70,15 @@ defmodule HighRoller.ParserTest do
       assert HighRoller.Parser.parse("invalid") == :error
     end
   end
+
+  describe "when returning the full result of a parse" do
+    test "it should return the results alongside the roll" do
+      HighRoller.RandomMock
+      |> stub(:roll, fn 2, 8 ->
+           [4, 8]
+         end)
+
+      assert HighRoller.Parser.parse_with_results("2d8+5") == %{total: 17, full_results: [[4, 8], :+, 5]}
+    end
+  end
 end


### PR DESCRIPTION
Implements a parse_with_results function that allows the caller to receive not only the final total of a roll, but the full results that generated it.